### PR TITLE
Fix default value for fabric8.launcher.endpointUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
             "title": "Fabric8 launcher",
             "properties": {
               "fabric8.launcher.endpointUrl": {
-                "default": "https://https://forge.api.openshift.io/api/",
+                "default": "https://forge.api.openshift.io/api/",
                 "type": "string",
                 "pattern": "https?://.*/",
                 "scope": "window",


### PR DESCRIPTION
Fix #1. It removes extra https:// prefix from api url default value